### PR TITLE
Add Google OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,20 @@ The server uses the `PORT` environment variable (default `3000`). You can place 
 ## Data Files
 
 - `pokemon-data-gen1.json` and `pokemon-data-gen2.json` contain Pokédex information for Generations 1 and 2.
-- Progress is saved under `save-data/` in files named `caught-<game>.json`. An example file is included as `example_caught.json`.
+- Progress is saved under `save-data/<USER_ID>/caught-<game>.json` where `<USER_ID>` is the unique Google account id. An example file is included as `example_caught.json`.
+
+## Authentication
+
+This app uses Google OAuth for login via [Passport](https://www.passportjs.org/). To run locally you will need to create a Google OAuth client and provide these variables in your `.env` file:
+
+```bash
+GOOGLE_CLIENT_ID=your-id
+GOOGLE_CLIENT_SECRET=your-secret
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+SESSION_SECRET=some_random_string
+```
+
+Once configured, start the server and click "Login with Google" on the homepage.
 
 ## Docker
 

--- a/app.js
+++ b/app.js
@@ -2,10 +2,42 @@ const express = require("express");
 const fs = require("fs");
 const dotenv = require("dotenv");
 const path = require("path");
+const session = require("express-session");
+const passport = require("passport");
+const GoogleStrategy = require("passport-google-oauth20").Strategy;
 
 const app = express();
 dotenv.config();
 app.use(express.json());
+
+const bypassAuth = process.env.BYPASS_AUTH_FOR_TESTS === 'true';
+
+app.use(session({
+    secret: process.env.SESSION_SECRET || 'change_this',
+    resave: false,
+    saveUninitialized: false
+}));
+
+passport.serializeUser((user, done) => done(null, user));
+passport.deserializeUser((obj, done) => done(null, obj));
+
+if (!bypassAuth) {
+    passport.use(new GoogleStrategy({
+        clientID: process.env.GOOGLE_CLIENT_ID || '',
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+        callbackURL: process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback'
+    }, (accessToken, refreshToken, profile, cb) => {
+        cb(null, { id: profile.id, displayName: profile.displayName });
+    }));
+}
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+function ensureAuthenticated(req, res, next) {
+    if (bypassAuth || req.isAuthenticated()) return next();
+    res.status(401).json({ error: 'Unauthorized' });
+}
 
 // Serve static files
 app.get("/", (req, res) => {
@@ -21,8 +53,33 @@ app.get("/pokemon-data-gen2.json", (req, res) => {
     res.sendFile(path.join(__dirname, "pokemon-data-gen2.json"));
 });
 
+// Authentication routes
+app.get('/auth/google', passport.authenticate('google', { scope: ['profile'] }));
+
+app.get('/auth/google/callback',
+    passport.authenticate('google', { failureRedirect: '/' }),
+    (req, res) => {
+        res.redirect('/');
+    }
+);
+
+app.get('/auth/user', (req, res) => {
+    if (req.isAuthenticated()) {
+        res.json({ id: req.user.id, displayName: req.user.displayName });
+    } else {
+        res.status(401).json({ error: 'not authenticated' });
+    }
+});
+
+app.get('/logout', (req, res) => {
+    req.logout(() => {
+        res.redirect('/');
+    });
+});
+
 function handleCaughtData(game, req, res, isPost = false) {
-    const filePath = path.join(__dirname, `save-data/caught-${game}.json`);
+    const userId = req.user?.id || 'guest';
+    const filePath = path.join(__dirname, 'save-data', userId, `caught-${game}.json`);
     if (isPost) {
         const { id, caught } = req.body;
         if (!fs.existsSync(path.dirname(filePath))) {
@@ -47,10 +104,10 @@ function handleCaughtData(game, req, res, isPost = false) {
 
 const supportedGames = ["red", "blue", "yellow", "gold", "silver", "crystal"];
 supportedGames.forEach(game => {
-    app.get(`/caught/${game}`, (req, res) => {
+    app.get(`/caught/${game}`, ensureAuthenticated, (req, res) => {
         handleCaughtData(game, req, res, false);
     });
-    app.post(`/caught/${game}`, (req, res) => {
+    app.post(`/caught/${game}`, ensureAuthenticated, (req, res) => {
         handleCaughtData(game, req, res, true);
     });
 });

--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
                     <option value="yellow">Pokémon Yellow</option>
                 </select>
             </div>
+            <div class="mt-4" id="authControls">
+                <span id="userInfo" class="mr-2 text-gray-700"></span>
+                <button id="loginButton" class="bg-blue-500 text-white px-3 py-1 rounded">Login with Google</button>
+                <button id="logoutButton" class="bg-gray-500 text-white px-3 py-1 rounded hidden">Logout</button>
+            </div>
         </header>
 
         <div class="mb-4 border-b border-gray-300">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.7",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      express-session:
+        specifier: ^1.18.1
+        version: 1.18.1
+      passport:
+        specifier: ^0.7.0
+        version: 0.7.0
+      passport-google-oauth20:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       jest:
         specifier: ^29.7.0
@@ -397,6 +406,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -503,8 +516,15 @@ packages:
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cookiejar@2.1.4:
@@ -650,6 +670,10 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-session@1.18.1:
+    resolution: {integrity: sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==}
+    engines: {node: '>= 0.8.0'}
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -1090,12 +1114,19 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  oauth@0.10.2:
+    resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
+
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
     engines: {node: '>= 0.4'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.0.2:
+    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -1129,6 +1160,22 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-google-oauth20@2.0.0:
+    resolution: {integrity: sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth2@1.8.0:
+    resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-strategy@1.0.0:
+    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
+    engines: {node: '>= 0.4.0'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1146,6 +1193,9 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  pause@0.0.1:
+    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1180,6 +1230,10 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
+
+  random-bytes@1.0.0:
+    resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
+    engines: {node: '>= 0.8'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1362,6 +1416,13 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  uid-safe@2.1.5:
+    resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
+    engines: {node: '>= 0.8'}
+
+  uid2@0.0.4:
+    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1961,6 +2022,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64url@3.0.1: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -2065,7 +2128,11 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
+  cookie-signature@1.0.7: {}
+
   cookie@0.7.1: {}
+
+  cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
 
@@ -2187,6 +2254,19 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-session@1.18.1:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      on-headers: 1.0.2
+      parseurl: 1.3.3
+      safe-buffer: 5.2.1
+      uid-safe: 2.1.5
+    transitivePeerDependencies:
+      - supports-color
 
   express@4.21.2:
     dependencies:
@@ -2813,11 +2893,15 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  oauth@0.10.2: {}
+
   object-inspect@1.13.3: {}
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.0.2: {}
 
   once@1.4.0:
     dependencies:
@@ -2850,6 +2934,26 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  passport-google-oauth20@2.0.0:
+    dependencies:
+      passport-oauth2: 1.8.0
+
+  passport-oauth2@1.8.0:
+    dependencies:
+      base64url: 3.0.1
+      oauth: 0.10.2
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
+      utils-merge: 1.0.1
+
+  passport-strategy@1.0.0: {}
+
+  passport@0.7.0:
+    dependencies:
+      passport-strategy: 1.0.0
+      pause: 0.0.1
+      utils-merge: 1.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -2859,6 +2963,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   path-to-regexp@0.1.12: {}
+
+  pause@0.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2891,6 +2997,8 @@ snapshots:
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
+
+  random-bytes@1.0.0: {}
 
   range-parser@1.2.1: {}
 
@@ -3086,6 +3194,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  uid-safe@2.1.5:
+    dependencies:
+      random-bytes: 1.0.0
+
+  uid2@0.0.4: {}
 
   undici-types@6.21.0: {}
 

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ let modal, modalPokemonName, modalPokemonSprite, modalCatchInfo, modalAvailabili
 let areaGameSelector, areaSelector, areaPokemonGrid;
 let tradeMyGameSelector, tradePartnerGameSelector, findTradesButton, canReceiveTradesList, canSendTradesList, tradeResultsPlaceholder;
 let tabButtons, tabContents;
+let loginButton, logoutButton, userInfo;
 
 // --- UTILITY FUNCTIONS for Pokemon Data Processing ---
 function processPokemonData(rawData) {
@@ -131,6 +132,10 @@ async function initializeApp() {
     canReceiveTradesList = document.getElementById('canReceiveTradesList');
     canSendTradesList = document.getElementById('canSendTradesList');
     tradeResultsPlaceholder = document.getElementById('tradeResultsPlaceholder');
+
+    loginButton = document.getElementById('loginButton');
+    logoutButton = document.getElementById('logoutButton');
+    userInfo = document.getElementById('userInfo');
 
     tabButtons = document.querySelectorAll('.tab-button');
     tabContents = document.querySelectorAll('.tab-content');
@@ -610,7 +615,27 @@ async function executeTradeSearch() {
 }
 
 // --- STARTUP ---
-document.addEventListener('DOMContentLoaded', initializeApp);
+async function checkAuth() {
+    loginButton.onclick = () => { window.location.href = '/auth/google'; };
+    logoutButton.onclick = () => { window.location.href = '/logout'; };
+    try {
+        const res = await fetch('/auth/user');
+        if (res.ok) {
+            const user = await res.json();
+            userInfo.textContent = `Logged in as ${user.displayName}`;
+            loginButton.classList.add('hidden');
+            logoutButton.classList.remove('hidden');
+            await initializeApp();
+        } else {
+            loginButton.classList.remove('hidden');
+            logoutButton.classList.add('hidden');
+        }
+    } catch (err) {
+        loginButton.classList.remove('hidden');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', checkAuth);
 
 window.onclick = (event) => {
     if (modal && event.target == modal) {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,14 +1,19 @@
 const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
+process.env.BYPASS_AUTH_FOR_TESTS = 'true';
 const app = require('../app');
 
-const savePath = path.join(__dirname, '..', 'save-data', 'caught-red.json');
+const savePath = path.join(__dirname, '..', 'save-data', 'guest', 'caught-red.json');
 
 describe('server routes', () => {
   afterAll(() => {
     if (fs.existsSync(savePath)) {
       fs.unlinkSync(savePath);
+      const dir = path.dirname(savePath);
+      if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
+        fs.rmdirSync(dir);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- integrate Google OAuth via `passport` and `express-session`
- add login/logout buttons and auth checks on the client
- store caught data per Google user id
- document authentication setup
- adjust tests for new auth layer

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843c7283cfc832f941d151492c232ab